### PR TITLE
add percent unit to FIO2

### DIFF
--- a/observation_types.json
+++ b/observation_types.json
@@ -2,7 +2,7 @@
 	"FIO2": 
 	{
 		"display_string": "FIO2",
-		"unit_code": "",
+		"unit_code": "%",
 		"loinc_code": "19996-8"
 	},
 	"PIP": 


### PR DESCRIPTION
Later we may add some observation types to support the data source we want to create for https://github.com/KitwareMedical/lungair-web-application/issues/9
but that seems to not be needed yet as FIO2 and HR are enough for testing functionality