### PR TITLE
make module paths easier to specify in data source config

### DIFF
--- a/data_sources/mimic3.json
+++ b/data_sources/mimic3.json
@@ -5,5 +5,5 @@
 		"mimic3_schemas_dir": "./mimic3-schemas/"
 	},
 	"class_name": "Mimic3",
-	"module_path": "./data_sources/mimic3.py"
+	"module_path": "./mimic3.py"
 }

--- a/data_sources/random.json
+++ b/data_sources/random.json
@@ -5,5 +5,5 @@
 		"num_of_observations_per_patient": 50
 	},
 	"class_name": "RandomDataSource",
-	"module_path": "./data_sources/random_data.py"
+	"module_path": "./random_data.py"
 }

--- a/example/README.md
+++ b/example/README.md
@@ -163,14 +163,14 @@ a new JSON config file that contains the appropriate paths and arguments:
             "csv_file": "./example/example.csv"
         },
         "class_name": "ExampleDataSource",
-        "module_path": "./example/example_data_source.py"
+        "module_path": "./example_data_source.py"
     }
 
 ```
 
-- `args` are the arguements passed into the `PatientDataSource.__init__` implementation.
+- `args` are the arguements passed into the `PatientDataSource.__init__` implementation. In this example the arguments happen to be filesystem paths, and they are given relative to the expected working directory when the `populate_fhir_server_script` is executed, just because of the way `ExampleDataSource.__init__` happens to be written.
 - `class_name` is the name of the `PatientDataSource` subclass.
-- `module_path` is the path to the `PatientDataSource` implementation.
+- `module_path` is the path to the `PatientDataSource` implementation. The path here should always be _relative to the directory containing the json file_.
 
 After following these steps, we should be able to run `populate_fhir_server.py` with the JSON config file as an argument.
 

--- a/example/example_data_source.json
+++ b/example/example_data_source.json
@@ -4,5 +4,5 @@
 		"csv_file": "./example/example.csv"
 	},
 	"class_name": "ExampleDataSource",
-	"module_path": "./example/example_data_source.py"
+	"module_path": "./example_data_source.py"
 }

--- a/populate_fhir_server.py
+++ b/populate_fhir_server.py
@@ -5,6 +5,7 @@ import importlib.util
 import os
 from fhirclient import client
 from transaction_bundles import create_transaction_bundle_object, post_transaction_bundle
+from pathlib import Path
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--json_file', type=str, help='JSON file for data generation to use', required=True)
@@ -12,11 +13,13 @@ parser.add_argument('--fhir_server', type=str, help='FHIR server', required=True
 
 args = parser.parse_args()
 
-with open(args.json_file) as json_file: # Import data source and create instance of data source
+json_path = Path(args.json_file)
+
+with open(json_path) as json_file: # Import data source and create instance of data source
   data_source_dict = json.load(json_file)
-  _, tail = os.path.split(data_source_dict['module_path'])
-  module_name = tail.split('.')[0]
-  spec = importlib.util.spec_from_file_location(module_name, data_source_dict['module_path'])
+  module_path = Path(data_source_dict['module_path'])
+  module_name = module_path.stem
+  spec = importlib.util.spec_from_file_location(module_name, (json_path.parent)/module_path)
   module = importlib.util.module_from_spec(spec)
   sys.modules[module_name] = module
   spec.loader.exec_module(module)


### PR DESCRIPTION
This makes a module path easier to specify in data source config by making it be relative to the json file rather than to the script that later uses the json file.

It's a bit confusing that any data paths that go into the `args` property of the json config end up being taken relative to the working directory when the `populate_fhir_server` script is run. But it's hard to get around this with the current setup, because each subclass of `PatientDataSource` can decide what args it wants to take and what it wants to do with them.

remaining todo:
- [x] Update the readme and tutorial and cmd help text to make it clear what the paths are relative to 