### PR TITLE
add openpyxl requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ idna==3.4
 isodate==0.6.1
 names==0.3.0
 numpy==1.23.4
+openpyxl==3.1.2
 pandas==1.5.1
 python-dateutil==2.8.2
 pytz==2022.5


### PR DESCRIPTION
this is used for some external data sources and it is more convenient to just always have it available in the environment in which we expect users to run populate_fhir_server.